### PR TITLE
Feat: useEllipsis

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ yarn add @react-cmpt/hooks
 - [useDebouncedClick](#useDebouncedClick)
 - [useDeepCompareCache](#useDeepCompareCache)
 - [useDeepEffect](#useDeepEffect)
+- [useEllipsis](#useEllipsis)
 - [useInterval](#useInterval)
 - [useLoadImg](#useLoadImg)
 - [useMountedState](#useMountedState)
@@ -224,6 +225,40 @@ const Demo = ({ value: Object }) => {
   // ...
 };
 ```
+
+### useEllipsis
+
+Hidden overflow content and get overflow status
+
+| option                   | type             | default | explain                                                       |
+| ------------------------ | ---------------- | ------- | ------------------------------------------------------------- |
+| content                  | `ReactNode`      | -       | Handle function. (setInterval callback)                       |
+| options.lineClamp        | number \| string | -       | The **`-webkit-line-clamp`** CSS property                     |
+| options.debouncedWait    | number           | 500     | The number of milliseconds to delay. **useDebouncedCallback** |
+| options.wrapperClassName | string           | -       | Wrapper element className                                     |
+| options.wrapperStyle     | Object           | -       | Wrapper element style                                         |
+| options.wrapperProps     | Object           | -       | Wrapper element other props                                   |
+
+| return           | type         | default | explain                           |
+| ---------------- | ------------ | ------- | --------------------------------- |
+| node             | `JSX.Elment` |         | Render element                    |
+| overflow         | boolean      | false   | Whether overflow content          |
+| reObserveElement | function     |         | Manual re-observe wrapper element |
+
+```tsx
+import { useEllipsis } from "@react-cmpt/hooks";
+
+const Demo = ({ text }) => {
+  const { node, overflow } = useEllipsis(text, { lineClamp: 2 });
+
+  return overflow ? <Tooltip content={text}>{node}</Tooltip> : node;
+};
+```
+
+Browser compatibility
+
+[-webkit-line-clamp](https://caniuse.com/mdn-css_properties_-webkit-line-clamp)
+[ResizeObserver API](https://caniuse.com/mdn-api_resizeobserver)
 
 ### useInterval
 

--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@ Hidden overflow content and get overflow status
 | options.wrapperClassName | string           | -       | Wrapper element className                                     |
 | options.wrapperStyle     | Object           | -       | Wrapper element style                                         |
 | options.wrapperProps     | Object           | -       | Wrapper element other props                                   |
+| options.defaultOverflow  | boolean          | -       | Default value of `overflow`                                   |
 
 | return           | type         | default | explain                           |
 | ---------------- | ------------ | ------- | --------------------------------- |

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ import { useDebouncedCallback } from "@react-cmpt/hooks";
 const Demo = () => {
   const [value, setValue] = useState();
   // Debounce callback
-  const [debouncedCallback] = useDebouncedCallback(
+  const debouncedCallback = useDebouncedCallback(
     // function
     (value) => {
       setValue(value);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,6 +4,7 @@ import useDebouncedCallback from "./useDebouncedCallback";
 import useDebouncedClick from "./useDebouncedClick";
 import useDeepCompareCache from "./useDeepCompareCache";
 import useDeepEffect from "./useDeepEffect";
+import useEllipsis from "./useEllipsis";
 import useInterval from "./useInterval";
 import useLoadImg from "./useLoadImg";
 import useMountedState from "./useMountedState";
@@ -21,6 +22,7 @@ export {
   useDebouncedClick,
   useDeepCompareCache,
   useDeepEffect,
+  useEllipsis,
   useInterval,
   useLoadImg,
   useMountedState,

--- a/src/useEllipsis.tsx
+++ b/src/useEllipsis.tsx
@@ -1,0 +1,122 @@
+import type { ReactNode, DetailedHTMLProps, CSSProperties } from "react";
+import React, {
+  useRef,
+  useMemo,
+  useEffect,
+  useCallback,
+  useState,
+} from "react";
+
+import useDebouncedCallback from "./useDebouncedCallback";
+
+type HTMLDIVProps = DetailedHTMLProps<
+  React.HTMLAttributes<HTMLDivElement>,
+  HTMLDivElement
+>;
+
+const defautEllipsisStyle: CSSProperties = {
+  whiteSpace: "nowrap",
+  overflow: "hidden",
+  textOverflow: "ellipsis",
+};
+
+export type WebkitLineClampType =
+  | "-moz-initial"
+  | "inherit"
+  | "initial"
+  | "revert"
+  | "unset"
+  | "none"
+  | number;
+
+const getEllipsisStyle = (lineClamp?: WebkitLineClampType): CSSProperties => {
+  if (lineClamp && typeof lineClamp === "number" && lineClamp > 1) {
+    return {
+      display: "-webkit-box",
+      WebkitBoxOrient: "vertical",
+      WebkitLineClamp: lineClamp,
+      overflow: "hidden",
+    };
+  }
+  return defautEllipsisStyle;
+};
+
+export type UseEllipsisOptions = {
+  lineClamp?: WebkitLineClampType;
+  debouncedWait?: number;
+  wrapperClassName?: string;
+  wrapperStyle?: CSSProperties;
+  wrapperProps?: Partial<HTMLDIVProps>;
+};
+
+export default function useEllipsis(
+  content?: ReactNode,
+  options?: UseEllipsisOptions
+) {
+  const {
+    lineClamp,
+    debouncedWait = 500,
+    wrapperClassName,
+    wrapperStyle,
+    wrapperProps,
+  } = options || {};
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const roRef = useRef<ResizeObserver>();
+  const [overflow, setOverflow] = useState(false);
+
+  const computeEllipsis = useCallback(() => {
+    const _el = wrapperRef.current;
+    if (_el) {
+      const _bool =
+        _el.scrollWidth > _el.offsetWidth ||
+        _el.scrollHeight > _el.offsetHeight;
+
+      setOverflow(_bool);
+    }
+  }, []);
+
+  const deComputeEllipsis = useDebouncedCallback(
+    computeEllipsis,
+    debouncedWait
+  );
+
+  const observerEl = useCallback(() => {
+    if (roRef.current) {
+      roRef.current.disconnect();
+
+      if (wrapperRef.current) {
+        roRef.current.observe(wrapperRef.current);
+      }
+    } else if (wrapperRef.current) {
+      roRef.current = new ResizeObserver(() => {
+        deComputeEllipsis();
+      });
+
+      roRef.current.observe(wrapperRef.current);
+    }
+  }, [deComputeEllipsis]);
+
+  useEffect(() => {
+    observerEl();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const node = useMemo(
+    () => (
+      <div
+        ref={wrapperRef}
+        className={wrapperClassName}
+        style={{
+          ...getEllipsisStyle(lineClamp),
+          ...wrapperStyle,
+        }}
+        {...wrapperProps}
+      >
+        {content}
+      </div>
+    ),
+    [content, lineClamp, wrapperClassName, wrapperProps, wrapperStyle]
+  );
+
+  return { node, overflow };
+}

--- a/src/useEllipsis.tsx
+++ b/src/useEllipsis.tsx
@@ -55,6 +55,10 @@ export type UseEllipsisOptions = {
   wrapperClassName?: string;
   wrapperStyle?: CSSProperties;
   wrapperProps?: Partial<HTMLDIVProps> | Record<string, string>;
+  /**
+   * Default value of `overflow`
+   */
+  defaultOverflow?: boolean;
 };
 
 /**
@@ -83,10 +87,11 @@ export default function useEllipsis(
     wrapperClassName,
     wrapperStyle,
     wrapperProps,
+    defaultOverflow,
   } = options || {};
   const wrapperRef = useRef<HTMLDivElement>(null);
   const roRef = useRef<ResizeObserver>();
-  const [overflow, setOverflow] = useState(false);
+  const [overflow, setOverflow] = useState(defaultOverflow ?? false);
 
   const computeEllipsis = useCallback(() => {
     const _el = wrapperRef.current;

--- a/src/useEllipsis.tsx
+++ b/src/useEllipsis.tsx
@@ -8,6 +8,7 @@ import React, {
 } from "react";
 
 import useDebouncedCallback from "./useDebouncedCallback";
+import useUpdateEffect from "./useUpdateEffect";
 
 type HTMLDIVProps = DetailedHTMLProps<
   React.HTMLAttributes<HTMLDivElement>,
@@ -95,6 +96,10 @@ export default function useEllipsis(
       roRef.current.observe(wrapperRef.current);
     }
   }, [deComputeEllipsis]);
+
+  useUpdateEffect(() => {
+    observerEl();
+  }, [overflow]);
 
   useEffect(() => {
     observerEl();

--- a/src/useEllipsis.tsx
+++ b/src/useEllipsis.tsx
@@ -43,17 +43,40 @@ const getEllipsisStyle = (lineClamp?: WebkitLineClampType): CSSProperties => {
 };
 
 export type UseEllipsisOptions = {
+  /**
+   *  The **`-webkit-line-clamp`** CSS property
+   */
   lineClamp?: WebkitLineClampType;
+  /**
+   * The number of milliseconds to delay. **useDebouncedCallback**
+   * @default 500
+   */
   debouncedWait?: number;
   wrapperClassName?: string;
   wrapperStyle?: CSSProperties;
-  wrapperProps?: Partial<HTMLDIVProps>;
+  wrapperProps?: Partial<HTMLDIVProps> | Record<string, string>;
 };
 
+/**
+ * hidden overflow content and get overflow status
+ */
 export default function useEllipsis(
   content?: ReactNode,
   options?: UseEllipsisOptions
-) {
+): {
+  /**
+   * render element
+   */
+  node: JSX.Element;
+  /**
+   * whether overflow content
+   */
+  overflow: boolean;
+  /**
+   * re-observe wrapper element
+   */
+  reObserveElement: () => void;
+} {
   const {
     lineClamp,
     debouncedWait = 500,
@@ -123,5 +146,5 @@ export default function useEllipsis(
     [content, lineClamp, wrapperClassName, wrapperProps, wrapperStyle]
   );
 
-  return { node, overflow };
+  return { node, overflow, reObserveElement: observerEl };
 }

--- a/tests/useEllipsis.test.tsx
+++ b/tests/useEllipsis.test.tsx
@@ -1,0 +1,25 @@
+import { renderHook } from "@testing-library/react-hooks";
+import { render, screen } from "@testing-library/react";
+
+import useEllipsis from "../src/useEllipsis";
+
+const SHORT_TEXT = "peace and love.";
+// const LONG_TEXT =
+//   "peace and love. peace and love. peace and love. peace and love. peace and love.";
+
+describe("useEllipsis", () => {
+  it("should be defined", () => {
+    expect(useEllipsis).toBeDefined();
+  });
+
+  it("render (short)", () => {
+    const { result } = renderHook(() => useEllipsis(SHORT_TEXT));
+
+    render(result.current.node);
+
+    const el = screen.getByText(SHORT_TEXT);
+    expect(el.textContent).toBe(SHORT_TEXT);
+    expect(el.style.textOverflow).toBe("ellipsis");
+    expect(result.current.overflow).toBeFalsy();
+  });
+});


### PR DESCRIPTION
Hidden overflow content and get overflow status

```tsx
import { useEllipsis } from "@react-cmpt/hooks";

const Demo = ({ text }) => {
  const { node, overflow } = useEllipsis(text, { lineClamp: 2 });

  return overflow ? <Tooltip content={text}>{node}</Tooltip> : node;
};
```